### PR TITLE
Fix ruTorrent utility functions

### DIFF
--- a/src/Archive.php
+++ b/src/Archive.php
@@ -98,7 +98,7 @@ class Archive {
             throw new Exception("Error Processing Request", 18);
         }
 
-        return Utility:getExternal($formatBin);
+        return Utility::getExternal($formatBin);
 
     }
     public  function extract($to)

--- a/src/Archive.php
+++ b/src/Archive.php
@@ -2,6 +2,7 @@
 namespace Flm;
 use \Exception;
 use Throwable;
+use Utility;
 
 class Archive {
     
@@ -97,7 +98,7 @@ class Archive {
             throw new Exception("Error Processing Request", 18);
         }
 
-        return getExternal($formatBin);
+        return Utility:getExternal($formatBin);
 
     }
     public  function extract($to)

--- a/src/BaseController.php
+++ b/src/BaseController.php
@@ -6,6 +6,7 @@ namespace Flm;
 use Exception;
 use ReflectionMethod;
 use RuntimeException;
+use CachedEcho;
 
 abstract class BaseController
 {
@@ -99,7 +100,7 @@ abstract class BaseController
 
     public static function jsonOut($data) {
 
-        cachedEcho(json_encode($data), 'application/json', false );
+        CachedEcho::send(json_encode($data), 'application/json', false );
     }
 
     public static function jsonError($errcode, $msg = 'Internal error') {

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -7,6 +7,8 @@ use Flm\Filesystem as Fs;
 use Flm\mediainfoSettings;
 use rTask;
 use Utility;
+use User;
+use FileUtil;
 
 class FileManager {
 
@@ -30,7 +32,7 @@ class FileManager {
         
        // $this->config = $config;
 
-		$this->userdir = addslash($topDirectory);
+		$this->userdir = FileUtil::addslash($topDirectory);
       
         $this->setWorkDir($directory);
 
@@ -57,12 +59,12 @@ class FileManager {
 
     
     public function getWorkDir($relative_path) {
-        return fullpath(trim($relative_path, DIRECTORY_SEPARATOR), $this->workdir);
+        return FileUtil::fullpath(trim($relative_path, DIRECTORY_SEPARATOR), $this->workdir);
     }
     
     public function getDirPath($path) {
         
-        return fullpath($path, $this->userdir);
+        return FileUtil::fullpath($path, $this->userdir);
     }
 
     public function extractChrootPath($fullPath) {
@@ -80,7 +82,7 @@ class FileManager {
     }
     
     public function getUserDir($relative_path) {
-         return fullpath(trim($relative_path, DIRECTORY_SEPARATOR), $this->userdir);
+         return FileUtil::fullpath(trim($relative_path, DIRECTORY_SEPARATOR), $this->userdir);
     }
 
     public function setFilelist($filelist) {
@@ -89,9 +91,9 @@ class FileManager {
     
     public function setWorkDir($directory) {
 
-        $dir = addslash($this->userdir. trim($directory, DIRECTORY_SEPARATOR)); 
+        $dir = FileUtil::addslash($this->userdir. trim($directory, DIRECTORY_SEPARATOR)); 
         
-        $path_check = explode($this->userdir, addslash(fullpath(  $dir, $this->userdir)));
+        $path_check = explode($this->userdir, FileUtil::addslash(fullpath(  $dir, $this->userdir)));
         if( count($path_check)  < 2 )
         {
             $dir = $this->userdir;
@@ -221,7 +223,7 @@ class FileManager {
 		
 		if(empty($sid)) {
 			session_start();
-			$_SESSION['uname'] = getUser();
+			$_SESSION['uname'] = User::getUser();
 			$sid = session_id();
 		}
 
@@ -232,7 +234,7 @@ class FileManager {
 
 		if($token === FALSE) {$this->sdie('No token');}
 
-		$k['tmp'] = addslash($this->settings['tempdir']).'.rutorrent/.fman/'.$token;
+		$k['tmp'] = FileUtil::addslash($this->settings['tempdir']).'.rutorrent/.fman/'.$token;
 		$k['pid'] = $k['tmp'].'/pid';
 		
 		if(!is_file($k['pid'])) {$this->output['errcode'] = 19; return false;};
@@ -287,7 +289,7 @@ class FileManager {
         $files = array_map(array($this, 'getWorkDir'), (array)$paths->fls);
         
         // destination dir requires ending /
-        $to = addslash($this->getUserDir($paths->to));
+        $to = FileUtil::addslash($this->getUserDir($paths->to));
       //  var_dump($paths,  $files);
         
         $fs =Fs::get(); 

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -6,6 +6,7 @@ use Flm\RemoteShell as Remote;
 use Flm\Filesystem as Fs;
 use Flm\mediainfoSettings;
 use rTask;
+use Utility;
 
 class FileManager {
 
@@ -272,7 +273,7 @@ class FileManager {
             file_put_contents( $randName, $st->data["mediainfotemplate"] );
             $flags = "--Inform=file://".escapeshellarg($randName);
         }
-        $commands[] = getExternal("mediainfo")." ".$flags." ".Helper::mb_escapeshellarg($filename);
+        $commands[] = Utility::getExternal("mediainfo")." ".$flags." ".Helper::mb_escapeshellarg($filename);
         $ret = $task->start($commands, rTask::FLG_WAIT);
 
 

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -93,7 +93,7 @@ class FileManager {
 
         $dir = FileUtil::addslash($this->userdir. trim($directory, DIRECTORY_SEPARATOR)); 
         
-        $path_check = explode($this->userdir, FileUtil::addslash(fullpath(  $dir, $this->userdir)));
+        $path_check = explode($this->userdir, FileUtil::addslash(FileUtil::fullpath(  $dir, $this->userdir)));
         if( count($path_check)  < 2 )
         {
             $dir = $this->userdir;

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -1,6 +1,7 @@
 <?php
 namespace Flm;
 
+use FileUtil;
 
 class Filesystem {
 
@@ -23,7 +24,7 @@ class Filesystem {
         
         $args = array('action' => 'recursiveCopy',
                         'params' => array('files' => $files,
-                                            'to' => addslash($to)
+                                            'to' => FileUtil::addslash($to)
                                             ),
                         'temp' => $temp );
                         
@@ -92,7 +93,7 @@ class Filesystem {
         $args = array('action' => 'recursiveMove',
                         'params' => array(
                             'files' => $files,
-                            'to' => addslash($to)),
+                            'to' => FileUtil::addslash($to)),
                         'temp' => $temp );
                         
          $task = $temp['dir'].'task';    

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -3,6 +3,7 @@ namespace Flm;
 
 use FileUtil;
 use Utility;
+use User;
 
 class Helper {
     
@@ -16,7 +17,7 @@ class Helper {
     protected static function newTempDir() {
 
         
-        $tmp['tok'] = getUser().time().rand(5, 20);
+        $tmp['tok'] = User::getUser().time().rand(5, 20);
         $tmp['dir'] = FileUtil::addslash(self::$config['tempdir']).'.rutorrent/.fman/'.$tmp['tok'].'/';
        
         

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -1,7 +1,8 @@
 <?php
 namespace Flm;
 
-use function getPluginConf;
+use FileUtil;
+use Utility;
 
 class Helper {
     
@@ -16,7 +17,7 @@ class Helper {
 
         
         $tmp['tok'] = getUser().time().rand(5, 20);
-        $tmp['dir'] = addslash(self::$config['tempdir']).'.rutorrent/.fman/'.$tmp['tok'].'/';
+        $tmp['dir'] = FileUtil::addslash(self::$config['tempdir']).'.rutorrent/.fman/'.$tmp['tok'].'/';
        
         
         Filesystem::get()->mkdir($tmp['dir'], true, 777);
@@ -30,7 +31,7 @@ class Helper {
         
          if($token !== null) {
                 return array('tok' => $token, 
-                             'dir' => addslash( addslash(self::$config['tempdir']).'.rutorrent/.fman/'.$token ),
+                             'dir' => FileUtil::addslash( FileUtil::addslash(self::$config['tempdir']).'.rutorrent/.fman/'.$token ),
                              );
          }
 
@@ -45,7 +46,7 @@ class Helper {
         return (pathinfo($file, PATHINFO_EXTENSION));
     }
     public static function getTaskCmd() {
-        return getExternal("php"). ' '. dirname(__FILE__) .'/..'. DIRECTORY_SEPARATOR. self::task_file;
+        return Utility::getPHP(). ' '. dirname(__FILE__) .'/..'. DIRECTORY_SEPARATOR. self::task_file;
     }
     
     public static function escapeCmdArgs( $args) {
@@ -127,7 +128,7 @@ class Helper {
 
      //       var_dump(__METHOD__, 'loaoding config');
 
-            eval(getPluginConf('filemanager'));
+            eval(FileUtil::getPluginConf('filemanager'));
 
             if(!isset($config))
             {

--- a/src/WebController.php
+++ b/src/WebController.php
@@ -1,6 +1,7 @@
 <?php
 namespace Flm;
 use Exception;
+use CachedEcho;
 
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . '/BaseController.php';
 // web controller
@@ -80,7 +81,7 @@ class WebController extends BaseController {
         $sf = $this->flm()->getWorkDir($data['target']);
         
         if (!sendFile($sf)) {
-            cachedEcho('log(theUILang.fErrMsg[6]+" - ' . $sf . ' / "+theUILang.fErrMsg[3]);', "text/html");
+            CachedEcho::send('log(theUILang.fErrMsg[6]+" - ' . $sf . ' / "+theUILang.fErrMsg[3]);', "text/html");
         }
     }
 


### PR DESCRIPTION
The utility functions were recently changed in ruTorrent. https://github.com/Novik/ruTorrent/pull/2247 They are no longer in the global scope. It's required to access these static methods from their respective classes now.

This PR is currently pending review to fix auto loading the utility classes from namespaces. https://github.com/Novik/ruTorrent/pull/2253

I was not able to setup a testing environment conducive for this pull request. There might be more changes required.