### PR TITLE
Update plugin

### DIFF
--- a/conf.php
+++ b/conf.php
@@ -4,15 +4,14 @@ global $pathToExternals;
 // set with fullpath to binary or leave empty
 $pathToExternals['rar'] = '';
 $pathToExternals['zip'] = '';
-$pathToExternals['unzip'] = '/usr/bin/unzip';
+$pathToExternals['unzip'] = '';
 $pathToExternals['tar'] = '';
 
-
-$config['mkdperm'] = 755; 		// default permission to set to new created directories
+$config['mkdperm'] = 755; // default permission to set to new created directories
 $config['show_fullpaths'] = false; // wheter to show userpaths or full system paths in the UI
 
-
 $config['textExtensions'] = 'log|txt|nfo|sfv|xml|html';
+
 // archive mangling, see archiver man page before editing
 // archive.fileExt -> config
 $config['archive']['type'] = [

--- a/js/app.js
+++ b/js/app.js
@@ -124,6 +124,8 @@
                     case 'gif':
                         iko += 'sprite-image';
                         break;
+                    case 'log':
+                    case 'txt':
                     case 'nfo':
                         iko += 'sprite-nfo';
                         break;
@@ -373,7 +375,7 @@
                 .get('filemanager');
         };
 
-        var pluginUrl = getPlugin().path; //'plugins/filemanager';
+        var pluginUrl = getPlugin().path; // = 'plugins/filemanager/';
         var flm = {
             EVENTS: getPlugin().ui.EVENTS,
             currentPath: null,
@@ -563,7 +565,7 @@
         var views = function () {
 
             var self = {};
-            self.viewsPath = pluginUrl + '/views';
+            self.viewsPath = pluginUrl + 'views';
             self.namespaces = {'flm': self.viewsPath + '/'};
 
 
@@ -574,7 +576,7 @@
             }
 
             self.getView = function (name, options, fn) {
-                //
+
                 options = options || {};
                 var filename = name + '.twig';
 
@@ -1076,7 +1078,7 @@
                         }
                         menu.push([CMENU_SEP]);
 
-                        if (utils.isArchive(target) && !(entries.length > 1)) {
+                        if (utils.isArchive(target)) {
                             menu.push([theUILang.fExtracta, "flm.ui.getDialogs().showDialog('extract')"]);
                             menu.push([CMENU_SEP]);
                         }

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/da.js
+++ b/lang/da.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/de.js
+++ b/lang/de.js
@@ -49,6 +49,8 @@ theUILang.fErrMsg[24]	= 'Archiv Manipulation deaktiviert (Anwendung nicht gefund
 
 
 theUILang.flm_popup_mkdir		= 'Erstelle neues Verzeichnis';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Verzeichnis Name';
 theUILang.fDiagnodirname 	= 'Bitte Verzeichnisnamen eingeben!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -94,18 +96,19 @@ theUILang.fDiagSFVHashfile	= 'Speichere SFV-Datei nach:';
 theUILang.fDiagSFVempty	= 'Benenne die SFV-Datei';
 
 theUILang.flm_popup_archive	= 'Erstelle Archiv';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Typ:';
 theUILang.fDiagCArchVsize	= 'Dateigröße (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Speichern', 'Schnellste', 'Schnell', 'Normal', 'Gut', 'Beste'];
+theUILang.fManArComp.rar = ['Speichern', 'Schnellste', 'Schnell', 'Normal', 'Gut', 'Beste'];
 // zip
-theUILang.fManArComp[1] = ['Speichern', 'Schnell', 'Besser'];
+theUILang.fManArComp.zip = ['Speichern', 'Schnell', 'Besser'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Normal'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Zum Archiv hinzufügen:';
 theUILang.fDiagExtract	= 'Entpacke Archive';

--- a/lang/el.js
+++ b/lang/el.js
@@ -49,6 +49,8 @@ theUILang.fErrMsg[24]	= 'File Manager: archive manipulation disabled (applicatio
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'File permissions';
@@ -97,6 +99,7 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
@@ -109,7 +112,7 @@ theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'
 theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp.tar	= ['none', 'gzip', 'bzip2'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.flm_popup_extract	= 'Extract Archive';

--- a/lang/en.js
+++ b/lang/en.js
@@ -49,6 +49,8 @@ theUILang.fErrMsg[24]	= 'File Manager: archive manipulation disabled (applicatio
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'File permissions';
@@ -97,6 +99,7 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
@@ -109,7 +112,7 @@ theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'
 theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp.tar	= ['none', 'gzip', 'bzip2'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.flm_popup_extract	= 'Extract Archive';
@@ -118,7 +121,7 @@ theUILang.fDiagCompression	= 'Compression:';
 theUILang.flm_diag_extract_button		= 'Extract';
 theUILang.fDiagArchempty	= 'Please name an archive file';
 
-theUILang.fStarts = { 
+theUILang.fStarts = {
 	delete: 	'File removal started',
 	extract:	'Archive extraction started',
 	archive: 	'File archiving started',

--- a/lang/es.js
+++ b/lang/es.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -13,52 +13,54 @@ theUILang.fcheckSFV		= "Vérifier le SFV";
 theUILang.fMediaI		= "Media info";
 theUILang.fView			= "Voir";
 theUILang.fcreate		= "Créer";
-theUILang.fcNewDir		= "Créer un répertoire";
-theUILang.fcNewArchive		= 'Créer une archive';
+theUILang.fcNewDir		= "Créer un dossier";
+theUILang.fcNewArchive		= "Créer une archive";
 theUILang.fcNewTor		= "Créer un .torrent";
 theUILang.fcSFV			= "Créer un fichier SFV";
 theUILang.fRefresh		= "Rafraichir";
 
 theUILang.fErrMsg 		= [];
-theUILang.fErrMsg[1]		= "Échec du changement de répertoire.";
-theUILang.fErrMsg[2]		= "Le répertoire n'existe pas.";
+theUILang.fErrMsg[1]		= "Échec du changement de dossier.";
+theUILang.fErrMsg[2]		= "Le dossier n'existe pas.";
 theUILang.fErrMsg[3]		= "Permission refusée.";
-theUILang.fErrMsg[4]		= "Échec de la création du répertoire.";
+theUILang.fErrMsg[4]		= "Échec de la création du dossier.";
 theUILang.fErrMsg[5]		= "Fichier trop gros pour être manipulé.";
-theUILang.fErrMsg[6]		= "Aucun fichier/répertoire de ce type.";
+theUILang.fErrMsg[6]		= "Aucun fichier ou dossier de ce type.";
 theUILang.fErrMsg[7]		= "Échec du renommage - Existe déjà.";
 theUILang.fErrMsg[8]		= "Échec du renommage - Refusée.";
-theUILang.fErrMsg[9]		= "Récupération de la liste des répertoires hors délais.";
+theUILang.fErrMsg[9]		= "Récupération de l'arborescence des dossiers hors délai.";
 theUILang.fErrMsg[10]		= "Échec de la récupération du contenu du dossier.";
-theUILang.fErrMsg[11]		= "Action hors délais.";
+theUILang.fErrMsg[11]		= "Action hors délai.";
 theUILang.fErrMsg[12]		= "Quelque chose s'est mal passé.";
 theUILang.fErrMsg[13]		= "Erreur d'accès au fichier.";
-theUILang.fErrMsg[14]		= "Erreur avec Mediainfo.";
-theUILang.fErrMsg[15]		= "Les binaire de Mediainfo n'ont pas été trouvés, modifier votre config.php.";
-theUILang.fErrMsg[16]		= "LE fichier existe déjà.";
-theUILang.fErrMsg[17]		= "Le dossier temporaire n'est pas configuré, modifier votre config.php.";
+theUILang.fErrMsg[14]		= "Erreur avec MediaInfo.";
+theUILang.fErrMsg[15]		= "L'exécutable de MediaInfo n'a pas été trouvé, modifiez votre config.php.";
+theUILang.fErrMsg[16]		= "Le fichier existe déjà.";
+theUILang.fErrMsg[17]		= "Le dossier temporaire n'est pas configuré, modifiez votre config.php.";
 theUILang.fErrMsg[18]		= "Fichier non valide.";
 theUILang.fErrMsg[19]		= "Commande déjà terminée.";
 theUILang.fErrMsg[20]		= "Échec de l'arrêt du processus.";
 theUILang.fErrMsg[21]		= "L'action est terminée.";
-theUILang.fErrMsg[22]		= "Rien de marche avec.";
+theUILang.fErrMsg[22]		= "Rien à faire.";
 theUILang.fErrMsg[23]		= "Échec de l'action.";
-theUILang.fErrMsg[24]		= 'Manipulation des archives désactivée (applications introuvables)';
+theUILang.fErrMsg[24]		= "Manipulation des archives désactivée (application introuvable)";
 
 
 
 
 theUILang.flm_popup_mkdir	= "Créer un nouveau dossier";
+theUILang.flm_popup_mkdir_cpath = "Localisation :";
+theUILang.flm_popup_mkdir_new 	= 'Nouveau dossier';
 theUILang.fDiagndirname		= "Nom du dossier";
 theUILang.fDiagnodirname 	= "Veuillez entrer un nom de dossier.";
-theUILang.flm_popup_permissions = 'Permissions';
-theUILang.flm_popup_rename 	= "Renommer un fichier / dossier";
+theUILang.flm_popup_permissions = "Permissions";
+theUILang.flm_popup_rename 	= "Renommer un fichier/dossier";
 theUILang.fDiagRenameTo 	= "Renommer en :";
 theUILang.fDiagRenameBut	= "Renommer";
 theUILang.fDiagRenameEmpty	= "Veuillez entrer un nouveau nom.";
 theUILang.fDiagInvalidname	= "Nom invalide.";
 
-theUILang.fDiagAexist		= "Le fichier / dossier existe déjà.";
+theUILang.fDiagAexist		= "Le fichier/dossier existe déjà.";
 
 theUILang.fDiagStart		= "Démarrer";
 theUILang.fDiagStop		= "Stop";
@@ -67,23 +69,23 @@ theUILang.fDiagTo		= "Vers :";
 theUILang.fDiagNoPath		= "Destination non permise";
 
 
-theUILang.fDiagCopyBut		= 'Copier';
-theUILang.fDiagMoveBut 		= 'Déplacer';
+theUILang.fDiagCopyBut		= "Copier";
+theUILang.fDiagMoveBut 		= "Déplacer";
 
-theUILang.flm_popup_delete	= "Supprimer des dossiers / fichiers";
-theUILang.fDiagDeleteSel	= "Fichiers marqués à supprimer :";
+theUILang.flm_popup_delete	= "Supprimer un ou plusieurs fichiers/dossiers";
+theUILang.fDiagDeleteSel	= "Élément(s) marqué(s) à supprimer :";
 theUILang.fDiagDeleteBut	= "Supprimer";
 
 theUILang.flm_popup_console	= "Console";
 
-theUILang.flm_popup_move	= "Déplacer des dossiers / fichiers";
-theUILang.fDiagMoveSel		= "Fichiers marqués à déplacer:";
-theUILang.fDiagMoveTo		= "Déplacer les fichiers vers :";
-theUILang.fDiagMoveEmpty	= "Veuillez sélectionne le chemin où doit être déplacés les fichiers.";
+theUILang.flm_popup_move	= "Déplacer un ou plusieurs fichiers/dossiers";
+theUILang.fDiagMoveSel		= "Élément(s) marqué(s) à déplacer :";
+theUILang.fDiagMoveTo		= "Déplacer vers :";
+theUILang.fDiagMoveEmpty	= "Veuillez sélectionner l'endroit où déplacer le ou les éléments.";
 theUILang.fDiagMoveFalse	= "Chemin non permis";
 
-theUILang.flm_popup_copy	= "Copier des dossiers / fichiers";
-theUILang.fDiagCopySel		= "Fichiers marqués pour le copiage:";
+theUILang.flm_popup_copy	= "Copier un ou plusieurs fichiers/dossiers";
+theUILang.fDiagCopySel		= "Élément(s) marqué(s) à copier :";
 theUILang.fDiagCopyTo		= "Copier vers :";
 
 theUILang.flm_popup_nfo_view	= "Lecteur de fichier texte";
@@ -91,25 +93,26 @@ theUILang.flm_popup_sfv_check	= "Simple File Verification";
 theUILang.fDiagSFVCheckf	= "Fichier checksum :";
 
 theUILang.flm_popup_sfv_create	= "Créer un fichier SFV";
-theUILang.fDiagSFVCreateSel	= "Fichiers marqués pour le hashage :";
-theUILang.fDiagSFVHashfile	= "Enregister le fichier vers :";
+theUILang.fDiagSFVCreateSel	= "Élément(s) sélectionné(s) pour le hashage :";
+theUILang.fDiagSFVHashfile	= "Enregister le fichier de hash vers :";
 
 theUILang.fDiagSFVempty		= "Veuillez nommer le fichier de hash.";
 
 theUILang.flm_popup_archive	= "Créer une archive";
-theUILang.fDiagCArchType	= "Type:";
-theUILang.fDiagCArchVsize	= "Taille des volumes (Mo):";
+theUILang.fDiagOptions		= "Options :";
+theUILang.fDiagCArchType	= "Type :";
+theUILang.fDiagCArchVsize	= "Taille des volumes (en Mo) :";
 
-theUILang.fManArComp 		= []; 
+theUILang.fManArComp 		= {};
 
 // rar
-theUILang.fManArComp.rar 	= ["Stocker", "Très rapide", "Rapide", "Normal", "Bon", "Meilleur"];
+theUILang.fManArComp.rar 	= ["Aucune", "La plus rapide", "Rapide", "Normale", "Bonne", "La meilleure"];
 
 // zip
-theUILang.fManArComp.zip 	= ["Stocker", "Rapide", "Meilleur"];
+theUILang.fManArComp.zip 	= ["Aucune", "Rapide", "La meilleure"];
 
 // tar
-theUILang.fManArComp.tar	= ['none', 'gzip', 'bzip2'];
+theUILang.fManArComp.tar 	= ["aucune", "gzip", "bzip2"];
 
 theUILang.fDiagCArchiveSel	= "Ajouter à l'archive :";
 theUILang.fDiagExtract		= "Extraire une archive";
@@ -118,24 +121,24 @@ theUILang.fDiagCompression	= "Compression :";
 theUILang.flm_diag_extract_button = "Extraire";
 theUILang.fDiagArchempty	= "Veuillez entrer un nom d'archive.";
 
-theUILang.fStarts = { 
-	delete: 	"Suppression des fichiers démarrée.",
-	extract:	"Extraction de l'archive démarrée.",
-	archive: 	"Mise en archive démarrée.",
+theUILang.fStarts = {
+	delete: 	"Suppression démarrée.",
+	extract:	"Extraction démarrée.",
+	archive: 	"Création d'une archive démarrée.",
 	check_sfv: 	"Vérification du hash démarrée.",
 	create_sfv:	"Calcul du hash démarré.",
-	move:		"Déplacement des fichiers démarré.",
-	copy:		"Copiage des fichiers démarré."
+	move:		"Déplacement démarré.",
+	copy:		"Copie démarrée."
 };
 
-theUILang.fStops = { 
-	Delete: 	"Suppression des fichiers arrêtée.",
-	Extract:	"Extraction de l'archive arrêtée.",
-	CArchive: 	"Mise en archive arrêtée.",
+theUILang.fStops = {
+	Delete: 	"Suppression arrêtée.",
+	Extract:	"Extraction arrêtée.",
+	CArchive: 	"Création d'une archive arrêtée.",
 	CheckSFV: 	"Vérification du hash arrêtée.",
 	CreateSFV:	"Calcul du hash arrêté.",
-	Move:		"Déplacement des fichiers arrêté.",
-	Copy:		"Copiage des fichiers arrêté."
+	Move:		"Déplacement arrêté.",
+	Copy:		"Copie arrêtée."
 };
 
 thePlugins.get("filemanager").langLoaded();

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/it.js
+++ b/lang/it.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -49,6 +49,8 @@ theUILang.fErrMsg[24]	= 'File Manager: archive manipulation disabled (applicatio
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'File permissions';
@@ -97,6 +99,7 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
@@ -109,7 +112,7 @@ theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'
 theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp.tar	= ['none', 'gzip', 'bzip2'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.flm_popup_extract	= 'Extract Archive';

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/no.js
+++ b/lang/no.js
@@ -49,6 +49,8 @@ theUILang.fErrMsg[24]	= 'File Manager: archive manipulation disabled (applicatio
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'File permissions';
@@ -97,6 +99,7 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
@@ -109,7 +112,7 @@ theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'
 theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp.tar	= ['none', 'gzip', 'bzip2'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.flm_popup_extract	= 'Extract Archive';

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -49,6 +49,8 @@ theUILang.fErrMsg[24]	= 'File Manager: archive manipulation disabled (applicatio
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'File permissions';
@@ -97,6 +99,7 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
@@ -109,7 +112,7 @@ theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'
 theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp.tar	= ['none', 'gzip', 'bzip2'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.flm_popup_extract	= 'Extract Archive';

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -98,18 +100,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -50,6 +50,8 @@ theUILang.fErrMsg[24]	= 'archive manipulation disabled (application not found)';
 
 
 theUILang.flm_popup_mkdir		= 'Create new directory';
+theUILang.flm_popup_mkdir_cpath = 'Inside path:';
+theUILang.flm_popup_mkdir_new 	= 'New Folder';
 theUILang.fDiagndirname	= 'Directory name';
 theUILang.fDiagnodirname 	= 'Please enter a directory name!';
 theUILang.flm_popup_permissions = 'Permissions';
@@ -95,18 +97,19 @@ theUILang.fDiagSFVHashfile	= 'Save hash file to:';
 theUILang.fDiagSFVempty	= 'Please name a sfv file';
 
 theUILang.flm_popup_archive	= 'Create Archive';
+theUILang.fDiagOptions		= 'Options:';
 theUILang.fDiagCArchType	= 'Type:';
 theUILang.fDiagCArchVsize	= 'Volume size (mb):';
 
-theUILang.fManArComp = []; 
+theUILang.fManArComp = {}; 
 
 // rar
-theUILang.fManArComp[0] = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
+theUILang.fManArComp.rar = ['Store', 'Fastest', 'Fast', 'Normal', 'Good', 'Best'];
 // zip
-theUILang.fManArComp[1] = ['Store', 'Fast', 'Better'];
+theUILang.fManArComp.zip = ['Store', 'Fast', 'Better'];
 
 // tar
-theUILang.fManArComp[2]	= theUILang.fManArComp[3] = theUILang.fManArComp[4] = ['Default'];
+theUILang.fManArComp.tar = ['none', 'gzip', 'bzip2'];
 
 theUILang.fDiagCArchiveSel	= 'Add to archive:';
 theUILang.fDiagExtract	= 'Extract Archive';

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -192,9 +192,9 @@ class FileManager
         return $res;
     }
 
-    public function mediainfo($paths)
+    public function mediainfo($path)
     {
-        $file = $this->currentDir($paths->target);
+        $file = $this->currentDir($path->target);
 
         if (!$this->fs->isFile($file)) {
             throw new Exception( $file, 6);
@@ -214,7 +214,7 @@ class FileManager
             file_put_contents($randName, $st->data["mediainfotemplate"]);
             $flags = "--Inform=file://" . escapeshellarg($randName);
         }
-        $commands[] = Utility::getExternal("mediainfo") . " " . $flags . " " . Helper::mb_escapeshellarg($this->getFsPath($paths->target));
+        $commands[] = Utility::getExternal("mediainfo") . " " . $flags . " " . Helper::mb_escapeshellarg($this->getFsPath($path->target));
         $ret = $task->start($commands, rTask::FLG_WAIT);
 
         return $ret;

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -35,7 +35,7 @@ class Filesystem
             throw new Exception($target, 16);
         }
 
-        $args = TaskController::mkdir($this->rootPath($target));
+        $args = TaskController::mkdir($this->rootPath($target), $recursive, $mode);
 
         if (!RemoteShell::get()->execOutput(array_shift($args), $args)) {
             throw new Exception("Error Processing Request", 4);

--- a/src/SFV.php
+++ b/src/SFV.php
@@ -65,17 +65,18 @@ class SFV implements \Iterator
     public function checkFileHash($against = null)
     {
 
-
         $parts = explode(' ', trim($this->file));
 
         if (count($parts) < 2) {
             throw new Exception("Invalid line " . implode(' ', $this->file), 1);
         }
 
-        $file = array_shift($parts);
-        $hash = array_pop($parts);
+        $read_hash = array_pop($parts);
 
-        return (self::getFileHash($file) == $hash);
+        $file = implode(' ', $parts);
+        $calc_hash = self::getFileHash($file);
+
+        return ($calc_hash === $read_hash);
 
     }
 
@@ -83,10 +84,11 @@ class SFV implements \Iterator
     {
 
         if (!is_file($file)) {
-            throw new \Exception(' FAILED: no such file ' . $file, 1);
+            throw new \Exception(' No such file found...', 1);
         }
 
         return hash_file('crc32b', $file);
+
     }
 
     public function length()

--- a/src/TaskController.php
+++ b/src/TaskController.php
@@ -153,64 +153,66 @@ CMD
 
     public function sfvCreate()
     {
-
         if (($sfvfile = fopen($this->info->params->target, "abt")) === FALSE) {
-
             $this->writeLog('0: SFV HASHING FAILED. File not writable ' . $this->info->params->target);
         }
 
         // comments
         fwrite($sfvfile, "; ruTorrent filemanager;\n");
 
-
         $check_files = new SFV($this->info->params->files);
-        $fcount = count($this->info->params->files);
 
+        $fcount = count($this->info->params->files);
 
         foreach ($check_files as $i => $sfvinstance) {
 
+            $i++;
+
             $file = $sfvinstance->getCurFile();
-            $msg = '(' . $i . '/' . $fcount . ') Hashing ' . basename($file) . ' ... ';
+
+            $msg = '(' . $i . '/' . $fcount . ') Hashing "' . $file . '" ... ';
 
             try {
+
                 $hash = SFV::getFileHash($file);
 
-                fwrite($sfvfile, end(explode('/', $file)) . ' ' . $hash . "\n");
+                $arr = explode('/', $file);
+                fwrite($sfvfile, end($arr) . ' ' . $hash . "\n");
                 $this->writeLog($msg . ' - OK ' . $hash);
+
             } catch (Exception $err) {
+
                 $this->writeLog($msg . ' - FAILED:' . $err->getMessage());
 
             }
 
-
         }
-
-        fclose($sfvfile);
-
-
+        $this->writeLog("\n--- Done");
     }
 
     public function sfvCheck()
     {
 
-
         $check_files = new SFV($this->info->params->target);
 
         $fcount = $check_files->length();
 
-
         foreach ($check_files as $i => $item) {
 
-            $file = $item->getCurFile();
+            $i++;
 
-            $msg = '(' . $i . '/' . $fcount . ') Checking ' . trim($file) . ' ... ';
+            $file = implode(' ', explode(' ', $item->getCurFile(), -1));
+
+            $msg = '(' . $i . '/' . $fcount . ') Checking "' . trim($file) . '" ... ';
 
             try {
 
                 if (!$item->checkFileHash()) {
-                    $this->writeLog($msg . '- FAILED: hash mismatch ');
+                    $this->writeLog($msg . '- Hash mismatch!');
+                } else {
+                    $this->writeLog($msg . '- OK');
                 }
-                $this->writeLog($msg . '- OK ');
+
             } catch (Exception $err) {
 
                 $this->writeLog($msg . '- FAILED:' . $err->getMessage());
@@ -218,9 +220,7 @@ CMD
             }
 
         }
-
-
-        $this->writeLog("OK: files match\n");
+        $this->writeLog("\n--- Done");
     }
 
 }

--- a/views/dialog-archive.twig
+++ b/views/dialog-archive.twig
@@ -13,7 +13,7 @@
 
  {{ window.pathBrowser(selectedTarget, theUILang.fDiagArchive) }}
 <fieldset>
-    <legend>Options:</legend>
+    <legend>{{ theUILang.fDiagOptions }}</legend>
     <label style="float: left;"> {{ theUILang.fDiagCArchType }}
         <select name="fMan_archtype" id="fMan_archtype">
 

--- a/views/dialog-new-dir.twig
+++ b/views/dialog-new-dir.twig
@@ -4,14 +4,14 @@
     <fieldset>
         <legend>{{ theUILang.fcNewDir }}</legend>
         <div style="padding-top:3px; padding-bottom:4px;">
-            <label for="flm_popup_mkdir-currentpath"><strong>Inside path: </strong></label>
-            <pre id="flm_popup_mkdir-currentpath" style="overflow-x: scroll">{{ currentPath }}</pre>
+            <label for="flm_popup_mkdir-cpath"><strong>{{ theUILang.flm_popup_mkdir_cpath }}</strong></label>
+            <pre id="flm_popup_mkdir-cpath" style="overflow-x: scroll">{{ currentPath }}</pre>
         </div>
         <label for="fMan-ndirname"><strong>{{ theUILang.Name }}:</strong></label>
         <input type="text"
                name="fMan-ndirname"
                id="fMan-ndirname"
-               value="New Folder"
+               value="{{ theUILang.flm_popup_mkdir_new }}"
                style="width:200px;"/>
     </fieldset>
 </div>
@@ -62,7 +62,7 @@
         flm.ui.getDialogs().onStart(function () {
             console.log('hello from dialog new dir twig');
             var dirname = flm.getCurrentPath($('#fMan-ndirname').val());
-            var currentPath = $('#flm_popup_mkdir-currentpath').val();
+            var currentPath = $('#flm_popup_mkdir-cpath').val();
             dirname = flm.utils.buildPath([currentPath, dirname]);
 
             if (!flm.utils.isValidPath(dirname)) {

--- a/views/dialog-window.twig
+++ b/views/dialog-window.twig
@@ -44,7 +44,7 @@
 </div>
 {% block navigation %}
     {% if pathbrowse %}
-        {{ window.pathBrowser(pathbrowse, 'To:') }}
+        {{ window.pathBrowser(pathbrowse, theUILang.fDiagTo) }}
    {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
- Unset the path for `pathToExternals['unzip']` in `conf.php`
- Display `nfo` icon for `log` and `txt` files
- Fix `viewsPath` (remove a double slash in path)
- Allow to select multiple files for extraction (extract multiple compressed files at once)
- Fix some translation files (for archives creation)
- More translations (elements) added
- Update french translation
- Fix filesystem (correctly change `temp` folders permissions)
- Fix SFV