### PR TITLE
Fix 'test' command

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -47,7 +47,6 @@ class Filesystem
     public function isDir($path) : bool
     {
         $path = $this->rootPath($path);
-
         return RemoteShell::test($path, 'd');
     }
 
@@ -159,7 +158,6 @@ class Filesystem
      */
     public function listDir($directory_path)
     {
-
         $output = [];
         $directory_path = $this->rootPath($directory_path);
 
@@ -189,7 +187,6 @@ class Filesystem
             $i++;
 
         }
-
 
         return $output;
     }


### PR DESCRIPTION
Avoid `Bad return code.` returned from 'test' command (via XMLRPC).