### PR TITLE
Use p7zip instead of 7z binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ Javascript web client with php endpoint with file operations methods
 ```php
 // if archive binaries are not in $PATH, set the fullpath
 $pathToExternals['rar'] = '';
-$pathToExternals['7zip'] = '';
+$pathToExternals['p7zip'] = '';
 
 $config['textExtensions'] = 'txt|nfo|sfv|xml|html';
-// see what 7zip extraction supports as type by file extension
+// see what p7zip extraction supports as type by file extension
 $config['fileExtractExtensions'] = '7z|bzip2|t?bz2|t?g|gz[ip]?|iso|img|lzma|rar|tar|t?xz|zip|z01|wim';
 
 // archive type extension and binary for new archive
 $config['archive']['type'] = [
     '7z' => [
-        'bin' =>'7z',
+        'bin' =>'p7zip',
         'compression' => [0, 5, 9],
     ],
     'rar' => [

--- a/conf.php
+++ b/conf.php
@@ -3,21 +3,21 @@
 global $pathToExternals;
 // set with fullpath to binary or leave empty
 $pathToExternals['rar'] = '';
-$pathToExternals['7zip'] = '';
+$pathToExternals['p7zip'] = '';
 
 $config['mkdperm'] = 755; // default permission to set to new created directories
 $config['show_fullpaths'] = false; // wheter to show userpaths or full system paths in the UI
 
 $config['textExtensions'] = 'log|txt|nfo|sfv|xml|html';
 
-// see what 7zip extraction supports as type by file extension
+// see what p7zip extraction supports as type by file extension
 $config['fileExtractExtensions'] = '7z|bzip2|t?bz2|t?g|gz[ip]?|iso|img|lzma|rar|tar|t?xz|zip|z01|wim';
 
 // archive creation, see archiver man page before editing
 // archive.fileExt -> config
 $config['archive']['type'] = [
     '7z' => [
-        'bin' =>'7z',
+        'bin' =>'p7zip',
         'compression' => [0, 5, 9],
     ],
     'rar' => [

--- a/plugin.info
+++ b/plugin.info
@@ -3,5 +3,5 @@ plugin.author: HWK
 plugin.version: 1.0
 rtorrent.remote: error
 rtorrent.external.error: php,pgrep,find
-web.external.error: 7z
+web.external.error: p7zip
 plugin.dependencies: _task

--- a/src/Archive.php
+++ b/src/Archive.php
@@ -150,7 +150,7 @@ class Archive
         }
         $type = pathinfo($archive, PATHINFO_EXTENSION);
 
-        $formatBin = isset($this->config['type'][$type]['bin']) ? $this->config['type'][$type]['bin'] : '7z';
+        $formatBin = isset($this->config['type'][$type]['bin']) ? $this->config['type'][$type]['bin'] : 'p7zip';
         return Utility::getExternal($formatBin);
     }
 }

--- a/src/ArchiveFormats.php
+++ b/src/ArchiveFormats.php
@@ -26,7 +26,7 @@ class ArchiveFormats
     }
 
     public static function extractCmd( $params) {
-        $bin = Utility::getExternal('7z');
+        $bin = Utility::getExternal('p7zip');
         $archive = Helper::mb_escapeshellarg($params->file);
         return vsprintf(self::$format_methods['7zipExtract'], [
             $bin,


### PR DESCRIPTION
This pull request uses the p7zip wrapper which is compatible with virtually every Linux operating system. Closes #26. This pull request needs to be tested before merging.