### PR TITLE
Fix Archive->compressCmd()

### DIFF
--- a/src/Archive.php
+++ b/src/Archive.php
@@ -29,7 +29,7 @@ class Archive
     public function compressCmd($o): string
     {
         $cmd = [];
-        $wrapper = $this->getCompressBin($o->binary)
+        $wrapper = P7zip::pack($o->archive)
             ->setFileList($o->fileList)
             ->setProgressIndicator(1);
 
@@ -49,8 +49,7 @@ class Archive
                 ->setStdOutput(false);
         }
 
-        $cmd[] = $wrapper->setArchiveFile($o->archive)
-            ->setVolumeSize($o->volumeSize > 0 ? $o->volumeSize : false)
+        $cmd[] = $wrapper->setVolumeSize($o->volumeSize > 0 ? $o->volumeSize : false)
             ->setPassword(isset($o->password) && strlen($o->password) > 0 ? $o->password : false)
             ->setCompression($o->compression ?? false)
             ->cmd();


### PR DESCRIPTION
It was written to try and support eventualy addition of Rar compression but until that's added we're failing to call setCommand(P7zip::EXTRACT_COMMAND)

Since this is only implemented in P7Zip, we replace it with the Archive::pack() convenience method, and if/when Rar support gets added down the road we can try to generalize the initilaztion more. Until then, we have precent already in extractCmd().

Fixes #31