### PR TITLE
Fix template loading if ruTorrent is hosted in a directory

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -55,7 +55,7 @@ import {FileManagerActions} from "./actions.js";
         };
 
         self.loadView = function (config, call) {
-            const templatePath = flm.utils.isValidPath(config.template) ? config.template : flm.utils.buildPath([self.viewsPath, config.template]);
+            const templatePath = flm.utils.isValidPath(config.template) ? config.template : '.' + flm.utils.buildPath([self.viewsPath, config.template]);
             flm.views.getView(templatePath, config.options, call, '.twig');
         }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -288,8 +288,7 @@ export function FileManagerUtils(flm) {
 
         utils.isValidPath = function (what) {
             what = what || '';
-            //starts with /
-            return (what.split('/').length > 1);
+            return what.includes('/');
         }
 
         utils.basename = function (what) {


### PR DESCRIPTION
flm.utils.buildPath() returns an asbolute path, which is generally desirable but if someone were hosting rutorrent at a subdirectory like /rutorrent/ then it will load from the domain root, instead of relative to /rutorrent/

Change "/" prefix to "./" to load relative to whatever page is currently loaded.

Also disambiguate the isValidPath() comment.