### PR TITLE
support full utf8 characters like unicode emoji 😍

### DIFF
--- a/conf.php
+++ b/conf.php
@@ -6,6 +6,13 @@ $pathToExternals['rar'] = '';
 $pathToExternals['7zip'] = '/usr/bin/7z';
 
 $config['debug'] = false;
+
+// slower workaround using rTask to support unicode emoji characters.
+// temporary till it gets fixed in rtorrent upstreams
+// issue: https://github.com/rakshasa/rtorrent/pull/1309
+// set to false for utf8 with no emoji chars support
+$config['unicode_emoji_fix'] = true;
+
 $config['mkdperm'] = 755; // default permission to set to new created directories
 
 $config['textExtensions'] = 'log|txt|nfo|sfv|xml|html';

--- a/src/RemoteShell.php
+++ b/src/RemoteShell.php
@@ -3,7 +3,6 @@
 namespace Flm;
 
 use Exception;
-use FileUtil;
 use rXMLRPCCommand;
 use rXMLRPCRequest;
 
@@ -93,8 +92,6 @@ class RemoteShell extends rXMLRPCRequest
         }
 
         $exitCode = $code;
-
-        Helper::getConfig("debug") && FileUtil::toLog(__METHOD__ . ' DEBUG cmd ' . var_export([$shell_cmd, trim($this->val[0])], true));
 
         return explode("\n", trim($this->val[0]));
     }

--- a/src/RemoteShell.php
+++ b/src/RemoteShell.php
@@ -16,7 +16,7 @@ class RemoteShell extends rXMLRPCRequest
     public static function test($target, $o): bool
     {
         $args = ['-' . $o, $target];
-        $res = ShellCmd::bin('test', $args)->runRemote();
+        $res = ShellCmd::bin('test', $args)->runRemote(true);
         $exitCode = $res[0];
         return ($exitCode === 0);
     }

--- a/src/ShellCmd.php
+++ b/src/ShellCmd.php
@@ -119,7 +119,7 @@ class ShellCmd
      * @return array
      * @throws Exception
      */
-    public function runRemote()
+    public function runRemote($force_clean = false)
     {
         $expectedCode = 255;
         if(Helper::getConfig("unicode_emoji_fix"))
@@ -133,7 +133,8 @@ class ShellCmd
             $output = $result['log'];
 
             $expectedCode = $result['status'];
-            $result['status'] == 0 && count($result['errors']) == 0 && rTask::clean(rTask::formatPath($task->id));
+            ($force_clean || ($result['status'] == 0 && count($result['errors']) == 0))
+            && rTask::clean(rTask::formatPath($task->id));
         } else {
             $output = RemoteShell::get()->execOutput($this, $expectedCode);
         }


### PR DESCRIPTION
slower workaround using rTask plugin to this rtorrent utf8 issue: https://github.com/rakshasa/rtorrent/pull/1309
temporary till it gets fixed in rtorrent upstreams
config variable in ``conf.php``:
```
$config['unicode_emoji_fix'] = true;
```
